### PR TITLE
add workgroup builtins test

### DIFF
--- a/src/test_kernel.zig
+++ b/src/test_kernel.zig
@@ -1,4 +1,5 @@
 const std = @import("std");
+const builtin = @import("builtin");
 
 test "basic" {}
 
@@ -7,6 +8,7 @@ test "skip" {
 }
 
 test "workgroup builtins" {
+    if (builtin.zig_backend != .stage2_spirv) return error.SkipZigTest;
     try std.testing.expectEqual(0, @workGroupId(0));
     try std.testing.expectEqual(1, @workGroupSize(0));
     try std.testing.expectEqual(0, @workItemId(0));


### PR DESCRIPTION
This test won't work on CPU backend.

Adding it would clarify how kernel test works.